### PR TITLE
Fix issue with unable to pass user id and group id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM erlang:26.0-alpine
 
-ARG USER_ID
-ARG GROUP_ID
+ARG USER_ID=1000
+ARG GROUP_ID=1000
 
 # Install git and create nonroot user
 RUN apk update && apk add --no-cache git; \
@@ -12,6 +12,9 @@ RUN apk update && apk add --no-cache git; \
 WORKDIR /rebar3
 ADD https://s3.amazonaws.com/rebar3/rebar3 ./
 ENV PATH="${PATH}:/rebar3"
+
+# Create /src directory and set ownership to nonroot user
+RUN mkdir /src && chown $USER_ID:$GROUP_ID /src
 
 # Use the nonroot user
 USER nonroot

--- a/rebar3.sh
+++ b/rebar3.sh
@@ -46,11 +46,7 @@ do
         DIR=`dirname "${BASH_SOURCE[0]}"`
         HASH=`git --git-dir=$DIR/.git rev-parse --short HEAD`
         NAME="pre-commit-erlang"
-        USER_ID=`id -u`
-        GROUP_ID=`id -u`
         $DOCKER build \
-                --build-arg $USER_ID \
-                --build-arg $GROUP_ID \
                 $DIR --tag $NAME:$HASH
         $DOCKER run --rm \
                 -v "$PWD/$a":/src:rw,Z \

--- a/rebar3.sh
+++ b/rebar3.sh
@@ -46,9 +46,11 @@ do
         DIR=`dirname "${BASH_SOURCE[0]}"`
         HASH=`git --git-dir=$DIR/.git rev-parse --short HEAD`
         NAME="pre-commit-erlang"
+        USER_ID=`id -u`
+        GROUP_ID=`id -u`
         $DOCKER build \
-                --build-arg USER_ID=$(id -u) \
-                --build-arg GROUP_ID=$(id -g) \
+                --build-arg $USER_ID \
+                --build-arg $GROUP_ID \
                 $DIR --tag $NAME:$HASH
         $DOCKER run --rm \
                 -v "$PWD/$a":/src:rw,Z \


### PR DESCRIPTION
This fixes the error

```
#0 3.814 OK: 24 MiB in 33 packages
#0 3.851 BusyBox v1.36.1 (2023-06-02 00:42:02 UTC) multi-call binary.
#0 3.851 
#0 3.851 Usage: addgroup [-g GID] [-S] [USER] GROUP
#0 3.851 
#0 3.851 Add a group or add a user to a group
#0 3.851 
#0 3.851        -g GID  Group id
#0 3.851        -S      Create a system group
#0 3.851 adduser: invalid number '--system'
------
ERROR: failed to solve: executor failed running [/bin/sh -c apk update && apk add --no-cache git;     addgroup -g $GROUP_ID nonroot;     adduser -u $USER_ID --system -G nonroot --disabled-password nonroot]: exit code: 1
```

Should still be tested to make sure the rebar3 actually works.