### PR TITLE
Update Dockerfile to remove nonroot user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,3 @@
 FROM erlang:26.0-alpine
 
-ARG USER_ID=1000
-ARG GROUP_ID=1000
-
-# Install git and create nonroot user
-RUN apk update && apk add --no-cache git; \
-    addgroup -g $GROUP_ID nonroot; \
-    adduser -u $USER_ID -S nonroot -G nonroot --disabled-password
-
-# Create /src directory and set ownership to nonroot user
-RUN mkdir /src && chown $USER_ID:$GROUP_ID /src
-
-# Use the nonroot user
-USER nonroot
+RUN apk update && apk add --no-cache git


### PR DESCRIPTION
rebar3 requires rewriting files, and thus needs to have ownership to make changes to cache and files.